### PR TITLE
feat: integrate timesync for sync playback

### DIFF
--- a/signaling-server/server.js
+++ b/signaling-server/server.js
@@ -17,6 +17,9 @@ app.use(cors());
 
 app.use(express.static(path.join(__dirname, '../public')));
 
+const timesyncServer = require('timesync/server');
+app.use('/timesync', timesyncServer.requestHandler);
+
 app.get('/api/ping', (req, res) => {
     res.send('pong');
 });


### PR DESCRIPTION
# {PR Name}
## Which issue(s) does this PR address?
 Makes playback on all devices synchronized
## Why do we need this PR?
 Necessary and important feature of jamsesh
## What logical changes are present in this PR?
 - Timesync is implemented.
 - Playback will occur after 500ms after the streamer starts playback, irrespective of individual client's latency.
 - Eg. new client joins with 300ms latency. Data will be sent after (500-300= 200ms) so playback happens at the same time. 
## How did you test the changes in this PR?
 - Ran locally.
## Are there any breaking changes in this PR?

## Is there some additional work to be done later that is NOT covered in this PR?
Most probably.